### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+BotWeb is a single-product **Next.js 14 (App Router) + TypeScript** marketing site (one public landing page at `/` with a contact form). There is no backend, database, or internal API — the only external integration is a client-side `fetch` POST to a hosted **Formspree** endpoint.
+
+Standard commands live in `package.json` (`dev`, `build`, `start`, `lint`); run them with `npm`.
+
+- Dev server: `npm run dev` → http://localhost:3000.
+- Lint: `npm run lint`. Build: `npm run build`.
+
+### Contact form / Formspree (non-obvious)
+- The contact form reads `NEXT_PUBLIC_FORMSPREE_URL` at build/runtime via `process.env`. Because it is a `NEXT_PUBLIC_*` var, it is inlined into the client bundle, so **changing it requires restarting `npm run dev`** (hot reload alone does not always pick up env changes).
+- If `NEXT_PUBLIC_FORMSPREE_URL` is unset, the form degrades gracefully: submitting shows an "email us directly" error and the rest of the site works. So the env var is OPTIONAL for running/most testing.
+- To exercise the full submit → "Thanks — we got your request." success flow without a real Formspree account, point `NEXT_PUBLIC_FORMSPREE_URL` (in a gitignored `.env.local`) at a tiny local mock HTTP server that returns `200 {"ok":true}` with permissive CORS headers, then restart the dev server.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for the BotWeb Next.js landing page, and adds an `AGENTS.md` with Cursor Cloud-specific notes for future agents.

This repo is a single-product **Next.js 14 (App Router) + TypeScript** marketing site (one public landing page with a contact form). The only external integration is a client-side POST to a hosted Formspree endpoint (optional; degrades gracefully).

## Environment setup
- Node `v22.14.0`, package manager **npm** (matches `package-lock.json`).
- Update script: `npm install`.

## Verification
- `npm install` — installed 420 packages.
- `npm run lint` — no ESLint warnings or errors.
- `npm run build` — compiled successfully (static export of `/`).
- `npm run dev` — serves at http://localhost:3000 (HTTP 200).
- Hello-world: filled and submitted the "Work with us" contact form and saw the "Thanks — we got your request." success state. The submit POST was confirmed received by a local mock Formspree endpoint (`NEXT_PUBLIC_FORMSPREE_URL` pointed at a local mock via gitignored `.env.local`).

[botweb_contact_form_submit.mp4](https://cursor.com/agents/bc-b01905a4-a41e-4f26-a15c-a17831dfd122/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbotweb_contact_form_submit.mp4)

[Contact form success state](https://cursor.com/agents/bc-b01905a4-a41e-4f26-a15c-a17831dfd122/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbotweb_contact_form_success.webp)

## Notes
- No application code changed. `package-lock.json` metadata rewrites from `npm install` were reverted to keep the repo unchanged.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b01905a4-a41e-4f26-a15c-a17831dfd122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b01905a4-a41e-4f26-a15c-a17831dfd122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

